### PR TITLE
Adding to inv adds to existing stacks before creating new stacks

### DIFF
--- a/lib/ItemList.cpp
+++ b/lib/ItemList.cpp
@@ -153,35 +153,39 @@ namespace tpublic
 
 		for (uint32_t i = 0; i < (uint32_t)m_entries.size() && i < aSize; i++)
 		{
+			if (remaining == 0)
+				break;
+
+			Entry& t = m_entries[i];
+
+			if (t.m_item.IsSet() && t.m_item.m_itemId == aItemId && t.m_item.m_quantity < aItemData->m_stackSize)
+			{
+				uint32_t t_amountToAdd = Base::Min(aItemData->m_stackSize - t.m_item.m_quantity, remaining);
+
+				remaining -= t_amountToAdd;
+				t.m_item.m_quantity += t_amountToAdd;
+			}
+		}
+
+		for (uint32_t i = 0; i < (uint32_t)m_entries.size() && i < aSize; i++)
+		{
+			if (remaining == 0)
+				break;
+
 			Entry& t = m_entries[i];
 
 			if (!t.m_item.IsSet())
 			{
-				uint32_t toAdd = remaining;
-				if (toAdd > aItemData->m_stackSize)
-					toAdd = aItemData->m_stackSize;
+				uint32_t t_amountToAdd = Base::Min(aItemData->m_stackSize, remaining);
 
-				remaining -= toAdd;
+				remaining -= t_amountToAdd;
 
 				ItemInstance itemInstance;
 				itemInstance.m_itemId = aItemId;
-				itemInstance.m_quantity = toAdd;
+				itemInstance.m_quantity = t_amountToAdd;
 
 				t.m_item = itemInstance;
 			}
-			else if (t.m_item.IsSet() && t.m_item.m_itemId == aItemId && t.m_item.m_quantity < aItemData->m_stackSize)
-			{
-				uint32_t toAdd = remaining;
-				if (toAdd > aItemData->m_stackSize - t.m_item.m_quantity)
-					toAdd = aItemData->m_stackSize - t.m_item.m_quantity;
-
-				remaining -= toAdd;
-
-				t.m_item.m_quantity += toAdd;
-			}
-
-			if (remaining == 0)
-				break;
 		}
 
 		m_version++;

--- a/lib/ItemList.cpp
+++ b/lib/ItemList.cpp
@@ -53,10 +53,10 @@ namespace tpublic
                 	uint32_t t_amountToAdd = Base::Min(aItemData->m_stackSize - t.m_item.m_quantity, remaining);
 					t.m_item.m_quantity += t_amountToAdd;
 					remaining -= t_amountToAdd;
-					m_version++;
 
 					if (remaining <= 0)
 					{
+						m_version++;
 						return true;
 					}
 				}


### PR DESCRIPTION
Methodology:
1st, check for any existing item stacks with the same item id
- If they are not already at max stack, find the smaller between the amount missing from the stack and the amount of item being added to the inventory
- Transfer said amount to the existing stack, keeping track of the remaining amount
- Repeat for all items in inventory

2nd, add item to a new slot with the remaining amount from the 1st pass