### PR TITLE
Make enemy debuffs unique effects not stack infinitely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 attic/
 data/maps/test.png
 data/_ids.txt
+.idea/

--- a/data/maps/dungeon-1/boss_umbracoth.txt
+++ b/data/maps/dungeon-1/boss_umbracoth.txt
@@ -7,9 +7,9 @@ loot_table .umbracoth:
 {
 	slots:
 	[
-		{ possibility: { loot_group: .umbracoth } }			
+		{ possibility: { loot_group: .umbracoth } }
 		!WORLD_DROPS{}
-	]	
+	]
 }
 
 ############################################################
@@ -25,43 +25,43 @@ encounter .umbracoth:
 		possible_entities: [ .umbracoth_spawn ]
 		entity_count: 1
 		interval: [ 70 100 ]
-		
+
 		condition<entity_health_less_than>:
 		{
 			id: dungeon_1_umbracoth
-			value: 70			
+			value: 70
 		}
-		
+
 		condition<entity_health_greater_than>:
 		{
 			id: dungeon_1_umbracoth
-			value: 15			
-		}		
+			value: 15
+		}
 	}
 }
 
-entity dungeon_1_umbracoth: !NPC 
-{ 
-	_string: "Umbracoth" 
+entity dungeon_1_umbracoth: !NPC
+{
+	_string: "Umbracoth"
 	_guild_name: "Messenger from the Void"
-	_level: 8 
+	_level: 8
 	_elite: true
-	_faction: monsters 
+	_faction: monsters
 	_sprite: tentacle_monster
-	_sprite_dead: tentacle_monster_dead 
+	_sprite_dead: tentacle_monster_dead
 	_weapon_damage: 1.5
 	_resource_health: 4
 	_loot_table: .umbracoth
 	_creature_type: demon
 	_encounter: .umbracoth
-	
-	_abilities: 
+
+	_abilities:
 	[
 		{
 			id: .umbracoth
 			target: random_player
 		}
-	
+
 		{
 			id: npc_attack
 		}
@@ -71,27 +71,27 @@ entity dungeon_1_umbracoth: !NPC
 ability .umbracoth_tick:
 {
 	string: "Void Condemnation"
-	icon: icon_holy_condemnation		
+	icon: icon_holy_condemnation
 	flags: [ always_in_range always_in_line_of_sight ]
-	
+
 	direct_effect damage:
-	{	
-		damage_type: unholy	
-		function: { expression: a a: 27 }													
-	}	
-	
+	{
+		damage_type: unholy
+		function: { expression: a a: 27 }
+	}
+
 }
 
 aura .umbracoth:
 {
 	string: "Void Condemnation"
-	icon: icon_holy_condemnation		
+	icon: icon_holy_condemnation
 	type: debuff
 	duration: based_on_effects
-	flags: [ magic ]
+	flags: [ unique magic ]
 	encounter: .umbracoth
-	aura_effect repeat: 
-	{ 
+	aura_effect repeat:
+	{
 		update_interval: 20
 		update_count: 10
 		ability: .umbracoth_tick
@@ -106,14 +106,14 @@ cooldown .umbracoth:
 ability .umbracoth:
 {
 	string: "Void Condemnation"
-	range: 10	
+	range: 10
 	cast_time: 10
 	cooldowns: [ global .umbracoth ]
 	flags: [ spell target_other target_hostile ]
 	icon: icon_holy_condemnation
 
 	direct_effect apply_aura:
-	{	
+	{
 		aura: .umbracoth
 	}
 }
@@ -126,16 +126,16 @@ map_trigger .umbracoth_killed:
 
 map_entity_spawn .umbracoth:
 {
-	entity dungeon_1_umbracoth: 
-	{ 
+	entity dungeon_1_umbracoth:
+	{
 		spawn_condition:
-		{	
+		{
 			if_not: .umbracoth_killed
 		}
 	}
 }
 
-npc_behavior_state .goblin_cultist: 
+npc_behavior_state .goblin_cultist:
 {
 	behavior: use_ability
 }
@@ -144,32 +144,32 @@ entity .goblin_cultist: !NPC
 {
 	_string: "Goblin Cultist"
 	_level: 8
-	_faction: monsters 
+	_faction: monsters
 	_sprite: goblin_shaman
-	_sprite_dead: goblin_shaman_dead 
+	_sprite_dead: goblin_shaman_dead
 	_weapon_damage: 1.7
 	_resource_health: 1.5
 	_resource_mana: 1
 	_creature_type: humanoid
 	_default_behavior_state: .goblin_cultist
 	_encounter: .umbracoth
-	
-	_default_abilities: 
-	[ 
-		{ 
-			id: .goblin_cultist 
-			target: [ dungeon_1_umbracoth ] 
-			use_probability: 10 
-		} 
-	]	
+
+	_default_abilities:
+	[
+		{
+			id: .goblin_cultist
+			target: [ dungeon_1_umbracoth ]
+			use_probability: 10
+		}
+	]
 }
 
 map_entity_spawn .goblin_cultist:
 {
-	entity .goblin_cultist: 
-	{ 
+	entity .goblin_cultist:
+	{
 		spawn_condition:
-		{	
+		{
 			if_not: .umbracoth_killed
 			encounter_not_active: .umbracoth
 		}
@@ -200,7 +200,7 @@ ability .goblin_cultist:
 	cooldowns: [ .goblin_cultist ]
 	string: "Suppression"
 	cast_time: 20
-	icon: icon_stuff	
+	icon: icon_stuff
 	direct_effect apply_aura:
 	{
 		aura: .goblin_cultist
@@ -212,9 +212,9 @@ entity .umbracoth_spawn: !NPC
 	_string: "Spawn of Umbracoth"
 	_level: 8
 	_elite: true
-	_faction: monsters 
+	_faction: monsters
 	_sprite: tentacle_monster_2
-	_sprite_dead: tentacle_monster_2_dead 
+	_sprite_dead: tentacle_monster_2_dead
 	_weapon_damage: 1.5
 	_resource_health: 0.7
 	_creature_type: demon

--- a/data/maps/open-world/npc_baldric_sunstrike.txt
+++ b/data/maps/open-world/npc_baldric_sunstrike.txt
@@ -1,23 +1,23 @@
 expression .baldric_sunstrike_follower:
 {
-	greater_than_or_equal: 
+	greater_than_or_equal:
 	{
-		client_reputation: 
+		client_reputation:
 		{
 			id<faction>: light
 		}
-		
+
 		constant: !WORSHIP_LEVEL_2{}
 	}
 }
 
 dialogue_screen .baldric_sunstrike_greetings:
 {
-	text: 
-	[	
-		"Greetings, fellow follower of the light."		
+	text:
+	[
+		"Greetings, fellow follower of the light."
 	]
-	
+
 	options:
 	[
 		{ quest: .baldric_sunstrike_1 }
@@ -26,8 +26,8 @@ dialogue_screen .baldric_sunstrike_greetings:
 
 dialogue_screen .baldric_sunstrike_greetings_2:
 {
-	text: 
-	[	
+	text:
+	[
 		"Serve The Light or die trying."
 	]
 }
@@ -39,7 +39,7 @@ dialogue_root .baldric_sunstrike_dialogue:
 }
 
 
-npc_behavior_state .baldric_sunstrike: 
+npc_behavior_state .baldric_sunstrike:
 {
 	behavior: use_ability
 }
@@ -47,51 +47,51 @@ npc_behavior_state .baldric_sunstrike:
 entity .baldric_sunstrike: !NPC
 {
 	_string: "Baldric Sunstrike"
-	_dialogue_root: .baldric_sunstrike_dialogue	
+	_dialogue_root: .baldric_sunstrike_dialogue
 	_sprite: man_20
-	_sprite_dead: man_20_dead	
+	_sprite_dead: man_20_dead
 	_level: 10
-	_faction: npcs		
+	_faction: npcs
 	_creature_type: humanoid
 	_loot_table: .npc
-	_not_pushable: true	
+	_not_pushable: true
 	_default_behavior_state: .baldric_sunstrike
-	_default_abilities: 
-	[ 
-		{ 
-			id: .baldric_sunstrike 
+	_default_abilities:
+	[
+		{
+			id: .baldric_sunstrike
 			target: random_player
-			use_probability: 10 
+			use_probability: 10
 			requirement target<must_have_negative_reputation>: light
 			requirement target<must_not_have_aura>: .baldric_sunstrike
-		} 
-	]		
+		}
+	]
 }
 
 ability .baldric_sunstrike_tick:
 {
 	string: "Holy Condemnation"
-	icon: icon_holy_condemnation		
+	icon: icon_holy_condemnation
 	flags: [ always_in_range always_in_line_of_sight ]
-	
+
 	direct_effect damage:
-	{	
-		damage_type: holy	
-		function: { expression: a a: 9 }													
-	}	
-	
+	{
+		damage_type: holy
+		function: { expression: a a: 9 }
+	}
+
 }
 
 aura .baldric_sunstrike:
 {
 	string: "Holy Condemnation"
 	description: "You've been condemned."
-	icon: icon_holy_condemnation		
+	icon: icon_holy_condemnation
 	type: debuff
 	duration: based_on_effects
-	flags: [ magic ]
-	aura_effect repeat: 
-	{ 
+	flags: [ unique magic ]
+	aura_effect repeat:
+	{
 		update_interval: 20
 		update_count: 10
 		ability: .baldric_sunstrike_tick
@@ -110,7 +110,7 @@ ability .baldric_sunstrike:
 	cooldowns: [ .baldric_sunstrike ]
 	string: "Holy Condemnation"
 	cast_time: 20
-	icon: icon_stuff	
+	icon: icon_stuff
 	direct_effect apply_aura:
 	{
 		aura: .baldric_sunstrike
@@ -125,8 +125,8 @@ loot_group .baldric_sunstrike_quest_item_1: { }
 item .baldric_sunstrike_quest_item_1:
 {
 	binds: when_picked_up
-	loot_groups: [ .baldric_sunstrike_quest_item_1 ]		
-	string: "Demon Blood" 
+	loot_groups: [ .baldric_sunstrike_quest_item_1 ]
+	string: "Demon Blood"
 	icon: icon_blood
 	stack: 6
 	item_level: 6
@@ -148,8 +148,8 @@ quest .baldric_sunstrike_1:
 	[
 		"Find the Temple of Luminara in eastern Eldertree Woods, kill demons, and collect their blood."
 	]
-	
-	description: 
+
+	description:
 	[
 		"You've arrive at the most dire time. The ancient Temple of Luminara, once a place of holy sanctuary, has fallen under foul corruption. Demons..."
 		"they've infested its sacred ruins.\n"
@@ -167,7 +167,7 @@ quest .baldric_sunstrike_1:
 	[
 		"Holy justice needs to be delivered."
 	]
-	
+
 	completion:
 	[
 		"$name$, you're back! And... I can feel it. The air feels lighter, the corruption that once tainted the temple has lifted. You've done it."
@@ -175,5 +175,5 @@ quest .baldric_sunstrike_1:
 
 	objectives: [ .baldric_sunstrike_1 ]
 	reward_one_item: [ ring_baldric_sunstrike_1 ranged_baldric_suntrike_1 head_baldric_suntrike_1 ]
-	level: 6	
+	level: 6
 }

--- a/data/npc-abilities.txt
+++ b/data/npc-abilities.txt
@@ -6,18 +6,18 @@ cooldown npc_attack:
 ability npc_attack:
 {
 	string: "Attack"
-	range: 1	
+	range: 1
 	cooldowns: [ global npc_attack ]
 	flags: [ melee attack offensive target_other target_hostile can_be_dodged can_be_parried can_be_blocked can_miss ]
 	states: [ in_combat ]
 	icon: icon_strike
 	delay: 3
-	
+
 	direct_effect damage:
 	{
 		flags: [ can_be_critical ]
 		damage_type: physical
-		function: { expression: x x: weapon }													
+		function: { expression: x x: weapon }
 	}
 }
 
@@ -29,18 +29,18 @@ cooldown npc_strike:
 ability npc_strike:
 {
 	string: "Strike"
-	range: 1	
+	range: 1
 	cooldowns: [ global npc_strike ]
 	flags: [ melee offensive target_other target_hostile can_be_dodged can_be_parried can_be_blocked can_miss ]
 	states: [ in_combat ]
 	icon: icon_strike
 	delay: 3
-	
+
 	direct_effect damage:
 	{
 		flags: [ can_be_critical ]
 		damage_type: physical
-		function: { expression: x_plus_a x: weapon a: [ [ 1 5 ] [ 10 20 ] ] }													
+		function: { expression: x_plus_a x: weapon a: [ [ 1 5 ] [ 10 20 ] ] }
 	}
 }
 
@@ -51,7 +51,7 @@ particle_system npc_firebolt:
 		sprites: [ effect_firebolt_b ]
 		flags: [ attached no_rotation face_target ]
 		scale: 0.4
-		count: 1	
+		count: 1
 	}
 }
 
@@ -66,13 +66,13 @@ ability npc_firebolt:
 	icon: icon_firebolt
 	speed: 6
 	projectile: npc_firebolt
-	resource_cost mana: 8	
-	
+	resource_cost mana: 8
+
 	direct_effect damage:
 	{
 		flags: [ can_be_critical ]
-		damage_type: fire		
-		function: { expression: a a: [ [ 1 12 ] [ 10 35 ] ] elite_multiplier: 1.7 }			
+		damage_type: fire
+		function: { expression: a a: [ [ 1 12 ] [ 10 35 ] ] elite_multiplier: 1.7 }
 	}
 }
 
@@ -84,14 +84,14 @@ cooldown npc_curse:
 ability npc_curse_tick:
 {
 	string: "Curse of Suffering"
-	icon: icon_holy_condemnation	
+	icon: icon_holy_condemnation
 	states: [ default in_combat ]
 	flags: [ always_in_range always_in_line_of_sight ]
-	
+
 	direct_effect damage:
 	{
 		damage_type: unholy
-		function: { expression: a a: [ [ 1 4 ] [ 10 10 ] ] elite_multiplier: 1.7 }			
+		function: { expression: a a: [ [ 1 4 ] [ 10 10 ] ] elite_multiplier: 1.7 }
 	}
 }
 
@@ -104,8 +104,8 @@ aura npc_curse:
 	duration: based_on_effects
 	flags: [ unique magic ]
 
-	aura_effect repeat: 
-	{ 
+	aura_effect repeat:
+	{
 		update_interval: 20
 		update_count: 6
 		ability: npc_curse_tick
@@ -122,7 +122,7 @@ ability npc_curse:
 	states: [ in_combat ]
 	icon: icon_holy_condemnation
 	delay: 3
-	
+
 	direct_effect apply_aura:
 	{
 		aura: npc_curse
@@ -137,14 +137,14 @@ cooldown npc_poison_bite:
 ability npc_poison_bite_tick:
 {
 	string: "Poison Bite"
-	icon: icon_poison	
+	icon: icon_poison
 	states: [ default in_combat ]
 	flags: [ always_in_range always_in_line_of_sight ]
-	
+
 	direct_effect damage:
 	{
 		damage_type: poison
-		function: { expression: a a: [ [ 1 2 ] [ 10 7 ] ] elite_multiplier: 1.7 }			
+		function: { expression: a a: [ [ 1 2 ] [ 10 7 ] ] elite_multiplier: 1.7 }
 	}
 }
 
@@ -155,9 +155,10 @@ aura npc_poison_bite:
 	type: debuff
 	icon: icon_poison
 	duration: based_on_effects
+	flags: [ unique ]
 
-	aura_effect repeat: 
-	{ 
+	aura_effect repeat:
+	{
 		update_interval: 25
 		update_count: 8
 		ability: npc_poison_bite_tick
@@ -167,21 +168,21 @@ aura npc_poison_bite:
 ability npc_poison_bite:
 {
 	string: "Poison Bite"
-	range: 1	
+	range: 1
 	cast_time: 15
 	cooldowns: [ global npc_poison_bite ]
 	flags: [ melee offensive target_other target_hostile can_miss interruptable ]
 	states: [ in_combat ]
 	icon: icon_strike
 	delay: 3
-	
+
 	direct_effect damage:
 	{
 		flags: [ can_be_critical ]
-		damage_type: poison		
-		function: { expression: a a: [ [ 1 4 ] [ 10 15 ] ] elite_multiplier: 1.7 }		
+		damage_type: poison
+		function: { expression: a a: [ [ 1 4 ] [ 10 15 ] ] elite_multiplier: 1.7 }
 	}
-	
+
 	direct_effect apply_aura:
 	{
 		aura: npc_poison_bite
@@ -191,18 +192,18 @@ ability npc_poison_bite:
 particle_system npc_shoot:
 {
 	particle:
-	{	
+	{
 		sprites: [ effect_arrow ]
 		flags: [ attached no_rotation face_target ]
 		scale: 0.3
-		count: 1			
-	}	
+		count: 1
+	}
 }
 
 ability npc_shoot:
 {
 	string: "Shoot"
-	range: 8	
+	range: 8
 	min_range: 3
 	cast_time: 20
 	cooldowns: [ global ]
@@ -211,12 +212,12 @@ ability npc_shoot:
 	icon: icon_throw_rock
 	speed: 7
 	projectile: npc_shoot
-	
+
 	direct_effect damage:
 	{
 		flags: [ can_be_critical ]
 		damage_type: physical
-		function: { expression: a_mul_x x: weapon a: 0.7 }													
+		function: { expression: a_mul_x x: weapon a: 0.7 }
 	}
 }
 
@@ -237,7 +238,7 @@ ability npc_heal:
 	delay: 3
 	resource_cost mana: 8
 	target_particle_system: heal
-	
+
 	direct_effect heal:
 	{
 		function: 20


### PR DESCRIPTION
Debuffs fixed:
Umbracoth's Void Condemnation
Spider Poison Bite
Baldric Sunstrike's Condemnation

Feel free to revert any of the changes I made to auras. In my opinion these seem more like bugs than intended features, since even the simple poison debuff on the spiders can add up to a ton of damage if enough of them stack onto you. Same issue with umbracoth's attack, the possibility to stack makes the aura seemingly unbalanced.

Also added the .gitignore for my IDE editor since it's a small change and should help any future contributors to keep commits clean.