### PR TITLE
"Scowl of the Sea" Quest Reward Fix

### DIFF
--- a/data/maps/thalvaron/nw/npc_fisherman.txt
+++ b/data/maps/thalvaron/nw/npc_fisherman.txt
@@ -183,7 +183,7 @@ objective .fisherman_4:
 {
 	${ _level: 12 _rarity: rare }
 	item .fisherman_4_a: !QUEST_REWARD_HEAD{ _string: "Carapace Skullguard" _icon: icon_head_3 _strength: 1 _constitution: 1 _type: armor_plate }
-	item .fisherman_4_b: !QUEST_REWARD_HEAD{ _string: "Scowl of the Sea" _icon: icon_wizard_hat_4 _mana_per_5: 1 _spell_damage: 1 itype: armor_cloth }
+	item .fisherman_4_b: !QUEST_REWARD_HEAD{ _string: "Scowl of the Sea" _icon: icon_wizard_hat_4 _mana_per_5: 1 _spell_damage: 1 _type: armor_cloth }
 	item .fisherman_4_c: !QUEST_REWARD_FINGER{ _string: "Salty Hoop" _icon: icon_ring_5 _wisdom: 1 _healing: 1 }
 }
 


### PR DESCRIPTION
Reported by Bonedog (bonedog_dhb) in Discord. (https://discord.com/channels/1043651040962158642/1370577041229086741/1370577041229086741)

"Reward Choice :Scowl of the Deep Has no AC modifier or Armor type."

Updated "itype: armor_cloth" to "_type: armor_cloth" which should fix the issue.