### PR TITLE
"Seaweed For Our Clawed Friends" Quest Reward Fix

### DIFF
--- a/data/maps/thalvaron/sw/npc_buck.txt
+++ b/data/maps/thalvaron/sw/npc_buck.txt
@@ -183,7 +183,7 @@ objective .buck_2:
 
 {
 	${ _level: 13 }
-	item .buck_2_a: !QUEST_REWARD_WAIST{ _string: "Musky Belt" _icon: icon_cape_1 _wisdom: 1 _constitution: 2 _type: armor_plate }
+	item .buck_2_a: !QUEST_REWARD_WAIST{ _string: "Musky Belt" _icon: icon_plate_belt_1 _wisdom: 1 _constitution: 2 _type: armor_plate }
 	item .buck_2_b: !QUEST_REWARD_HANDS{ _string: "Gardener's Gloves" _icon: icon_gloves_3 _wisdom: 2 _constitution: 1 _type: armor_cloth }
 }
 


### PR DESCRIPTION
Reported by Bonedog (bonedog_dhb) in Discord.
(https://discord.com/channels/1043651040962158642/1370579767937732709/1370579767937732709)

"Reward item: Musky Belt Item Sprite Icon of Cloak instead of a belt."

Changed "icon_cape_1" to "icon_plate_belt_1" which is a green-ish plate belt icon.