### PR TITLE
"Not Soft Enough" Quest Reward Fix

### DIFF
--- a/data/maps/thalvaron/n/npc_ronja_frostmane.txt
+++ b/data/maps/thalvaron/n/npc_ronja_frostmane.txt
@@ -113,7 +113,7 @@ item .ronja_frostmane_2_quest_item:
 {
 	${ _level: 13 }
   	item .ronja_frostmane_2_a: !QUEST_REWARD_2H_SWORD{ _string: "Sword of the Mountain" _icon: icon_sword_3 _constitution: 1 _dexterity: 1 _strength: 2 _weapon_cooldown: 30 }
-  	item .ronja_frostmane_2_b: !QUEST_REWARD_CHEST{ _string: "Frosty Wizard's Robe" _icon: icon_cloth_shirt_7 _constitution: 3 _spell_damage: 1 }	
+  	item .ronja_frostmane_2_b: !QUEST_REWARD_CHEST{ _string: "Frosty Wizard's Robe" _icon: icon_cloth_shirt_7 _constitution: 3 _spell_damage: 1 _type: armor_cloth }	
 }	   
 
 quest .ronja_frostmane_2:


### PR DESCRIPTION
Reported by Bonedog (bonedog_dhb) in Discord.
(https://discord.com/channels/1043651040962158642/1370439920300200089/1370439920300200089)

"Item Reward #2 (Frosty Wizard's Robe) has no AC modifier or Armor type."

"_type: armor_cloth" was missing on the end of the quest reward line