### PR TITLE
"Bogmaw's Claw" Quest Reward Fix

### DIFF
--- a/data/maps/thalvaron/sw/monsters.txt
+++ b/data/maps/thalvaron/sw/monsters.txt
@@ -324,11 +324,10 @@ map_entity_spawn thalvaron_swamp_giant:
 			_use_ability: $ability
 			{	
 				string: "Natural Remedy" 
-				icon: icon_brown_leaf_1
+				icon: @_icon
 				description: "Cures one poison effect."
 				cooldowns: [ global ]
 				cooldown: $cooldown { duration: 2400 }
-				icon: @_icon
 				flags: [ target_self item ]
 				requirement self<must_have_item_equipped>: .swamp_giant_1_a
 				direct_effect remove_aura: { aura_type: debuff aura_flags: [ poison ] }


### PR DESCRIPTION
Reported by Kierkan (kierkan) in Discord.
(https://discord.com/channels/1043651040962158642/1043651040962158645/1370969983529779355)

Maybe because it's referencing icon 2 times, the spell fails to initialize and can't be used.

I'm assuming that "icon: @_icon" is the syntax to reference the "_icon" listed above in "item .swamp_giant_1_a", which means an icon shouldn't need to be set again within the ability.