### PR TITLE
Guardian Paladin Threat Fix v1

### DIFF
--- a/data/classes/paladin/guardian.txt
+++ b/data/classes/paladin/guardian.txt
@@ -129,11 +129,18 @@ aura paladin_holy_reflection:
 {
 	flags: [ persist_in_death ]
 	type: hidden
-	description: "Causes holy damage to attackers when taking melee damage."
+	description: "Causes holy damage to attackers when taking melee damage or blocking."
 	
 	aura_effect combat_event_trigger: 
 	{ 
 		combat_event<target>: hit
+		combat_event_ability_mask: [ melee ]
+		ability<self>: paladin_holy_reflection		
+	}
+
+	aura_effect combat_event_trigger: 
+	{ 
+		combat_event<target>: block
 		combat_event_ability_mask: [ melee ]
 		ability<self>: paladin_holy_reflection		
 	}	
@@ -154,6 +161,12 @@ ability paladin_holy_reflection:
 		damage_type: holy
 		function: { expression: a_mul_x_plus_b x: spell_damage a: 0.3 b: [ [ 1 8 ] [ 10 16 ] [ 20 32 ] ] }													
 	}
+	
+	direct_effect threat:
+	{
+		add: 10
+		apply_to: source
+	}	
 }
 
 ###############################################################################


### PR DESCRIPTION
I talked with Cracker and I am going to submit a pull that modifies Holy Reflection to trigger on blocked melee hits and generates 10 threat when it activates.

Right now it only effects targets that directly hit you. If you block, dodge, or parry, you lose that damage. That directly punishes mitigation because you WANT block chance at the very least and it's built into the entire spec.

- Oath of Protection: "Increases your chance to block by 10%. Increases threat generated by 50%. You can only have one oath active at a time."
- Shield Specialization: "Increases your chance to block by 2/4/5/8/10%. Increases amount blocked by 12/24/36/48/60%."
- Block: "Increases your chance to block by 60% for 5 seconds."

If the stars align, you get 80% block chance before any gear. If you block, you don't deal damage via Holy Reflection, which means you aren't generating any kind of threat. Here is the kicker, it doesn't natively generate threat either.

FYI Paladins only have 2 threat generating abilities, both being 30 second cooldowns: 
- Judgement, generates 20 threat
- Consecrate, generates 20 threat per tick

We'll see how it goes and adjust further from there.