### PR TITLE
Spiritual Surge Range Fix

### DIFF
--- a/data/classes/priest/way-of-healing.txt
+++ b/data/classes/priest/way-of-healing.txt
@@ -65,7 +65,7 @@ ability spiritual_surge:
 {
 	string: "Spiritual Surge"
 	description: "Increases spell haste of friendly target by 30% for 10 seconds."
-	range: 1	
+	range: 3	
 	cooldowns: [ global spiritual_surge ]
 	flags: [ spell target_other target_self target_friendly ]
 	states: [ default in_combat ]


### PR DESCRIPTION
Kierkan (kierkan) and I talked via Discord about how awkward it can be to get Spiritual Surge to friendly targets.

(https://discordapp.com/channels/1043651040962158642/1371511626284404868/1371511626284404868)

I understand this could be powerful in PVP, so giving some kind of ranged ability without it being max range seems like the best solution. It still relies on communication and positioning instead of being like "range: 7" and able to hit it from pretty much anywhere.