### PR TITLE
Remove GCD From Class Pumping Abilites

### DIFF
--- a/data/classes/paladin/avenger.txt
+++ b/data/classes/paladin/avenger.txt
@@ -161,7 +161,7 @@ ability intervention_of_wrath:
 	string: "Intervention of Wrath"
 	description: "Your physical attacks cause target to take additional holy damage over 8 seconds. Effect lasts 20 seconds."
 	range: 1	
-	cooldowns: [ global intervention_of_wrath ]
+	cooldowns: [ intervention_of_wrath ]
 	flags: [ spell target_self ]
 	states: [ default in_combat ]
 	icon: icon_special_1

--- a/data/classes/priest/way-of-healing.txt
+++ b/data/classes/priest/way-of-healing.txt
@@ -66,7 +66,7 @@ ability spiritual_surge:
 	string: "Spiritual Surge"
 	description: "Increases spell haste of friendly target by 30% for 10 seconds."
 	range: 3	
-	cooldowns: [ global spiritual_surge ]
+	cooldowns: [ spiritual_surge ]
 	flags: [ spell target_other target_self target_friendly ]
 	states: [ default in_combat ]
 	icon: icon_special_4

--- a/data/classes/sorcerer/battle-mage.txt
+++ b/data/classes/sorcerer/battle-mage.txt
@@ -125,7 +125,7 @@ ability overpower:
 	string: "Overpower"
 	description: "Increases your Strength by 100% for 20 seconds."
 	range: 1	
-	cooldowns: [ global overpower ]
+	cooldowns: [ overpower ]
 	flags: [ target_self ]
 	states: [ default in_combat ]
 	icon: icon_agility

--- a/data/classes/sorcerer/elemental.txt
+++ b/data/classes/sorcerer/elemental.txt
@@ -130,7 +130,7 @@ ability elemental_infusion:
 	string: "Elemental Infusion"
 	description: "Increases the damage of your fire and frost spells by 50% for 20 seconds. All your spells cost 50% more mana to cast."
 	range: 1	
-	cooldowns: [ global elemental_infusion ]
+	cooldowns: [ elemental_infusion ]
 	flags: [ target_self ]
 	states: [ default in_combat ]
 	icon: icon_combustion

--- a/data/classes/witch/mallice.txt
+++ b/data/classes/witch/mallice.txt
@@ -75,7 +75,7 @@ ability maliciousness:
 	string: "Maliciousness"
 	description: "Increases your spell casting speed by 30% for 20 seconds."
 	range: 1	
-	cooldowns: [ global maliciousness ]
+	cooldowns: [ maliciousness ]
 	flags: [ target_self ]
 	states: [ default in_combat ]
 	icon: icon_special_9


### PR DESCRIPTION
This change comes from discussions with Kierkan (kierkan) and Yuhfaduh (nickkn) on class abilities that suffer from GCD.

(https://discord.com/channels/1043651040962158642/1371511626284404868/1371511626284404868) (https://discord.com/channels/1043651040962158642/1371650192872308809/1371650192872308809)

Fighters have Relentless Overpower that does not trigger a GCD (Global CoolDown.)

Right now, if I cast Spiritual Surge on myself, I cannot benefit from the +30% haste for 1.5 seconds. That means I lose 1.5 of 10 seconds I'm supposed to benefit from.

I looked around for similar buff abilities that have the global tag on them and removed them.

Sorcerer: Elemental Infusion
Sorcerer: Overpower
Priest: Spiritual Surge
Paladin: Intervention of Wrath
Witch: Maliciousness