### PR TITLE
"The Best Deal Ever" Quest Fix

### DIFF
--- a/data/maps/thalvaron/nw/npc_matthew_larsen.txt
+++ b/data/maps/thalvaron/nw/npc_matthew_larsen.txt
@@ -30,8 +30,8 @@ dialogue_screen .mathew_larsen_dialogue:
 		}	
 		
 		{ 
-			quest<completion_only>: thalvaron_gnome 
-			quest<completion_only>: open_world_randy_2
+			{ quest<completion_only>: thalvaron_gnome }
+			{ quest<completion_only>: open_world_randy_2 }
 		}
 	]
 }


### PR DESCRIPTION
In an effort to fix "Delivery to the City", I think we broke the "The Best Deal Ever" quest that you turn into Matthew Larson at Valoris.

I look through previous versions of npc_matthew_larsen.txt and compared it to other npcs with multiple quests. I think the brackets at the bottom might get them both fixed?