### PR TITLE
Tirnwood Thicket "Staff of Eldros" Fix

### DIFF
--- a/data/maps/tirnwood-thicket/boss_tree.txt
+++ b/data/maps/tirnwood-thicket/boss_tree.txt
@@ -44,7 +44,7 @@ loot_table .tree:
 		_weapon_cooldown: 36
 	}
 	
-	item tirnwood_thicket_15: !BOSS_DROP_CHEST
+	item tirnwood_thicket_15: !BOSS_DROP_2H_STAFF
 	{
 		_string: "Staff of Eldros"
 		_icon: icon_staff_4


### PR DESCRIPTION
Staff of Eldros dropped as a Chest Item instead of a Staff.

Updated it to !BOSS_DROP_2H_STAFF