### PR TITLE
Skeletal Captains Quest Fix: Change reward type from one to all items

### DIFF
--- a/data/maps/thalvaron/n/npc_warden_tylior.txt
+++ b/data/maps/thalvaron/n/npc_warden_tylior.txt
@@ -103,5 +103,5 @@ quest .warden_tylior_1:
 
 	objectives: [ .warden_tylior_1_a .warden_tylior_1_b .warden_tylior_1_c ]
 	level: 19
-	reward_one_item: [ .warden_tylior_1_a ]
+	reward_all_items: [ .warden_tylior_1_a ]
 }


### PR DESCRIPTION
Fix for minor bug reported here:
https://discord.com/channels/1043651040962158642/1447635541624619130

"When turning in the quest Skeletal Captains to Warden Tylior, the player is offered a reward selection option. In other quests that have offered a single item, no such selection is necessary and it is assumed/automatic/defaulted to that singular item."

Changed "reward_one_item" to "reward_all_items"